### PR TITLE
Ajustes para correta execução do cancelamento e captura das transações

### DIFF
--- a/eRede/eRede/Service/CancelTransactionService.cs
+++ b/eRede/eRede/Service/CancelTransactionService.cs
@@ -4,6 +4,7 @@ namespace eRede.Service
     {
         public CancelTransactionService(Store store, Transaction transaction) : base(store, transaction)
         {
+            this.tid = transaction?.tid; 
         }
 
         protected override string getUri()

--- a/eRede/eRede/Service/CaptureTransactionService.cs
+++ b/eRede/eRede/Service/CaptureTransactionService.cs
@@ -6,6 +6,7 @@ namespace eRede.Service
     {
         public CaptureTransactionService(Store store, Transaction transaction) : base(store, transaction)
         {
+            this.tid = transaction?.tid;
         }
 
         public TransactionResponse Execute()


### PR DESCRIPTION
Não estava sendo possível realizar um cancelamento ou captura, pois o tid não estava sendo informado nesses serviços.